### PR TITLE
Allow spaces for Runner Groups and Work Directory

### DIFF
--- a/common/entrypoint.sh
+++ b/common/entrypoint.sh
@@ -81,8 +81,8 @@ echo "Configuring GitHub Actions Runner and registering"
     --url "${RUNNER_URL}" \
     --token "${TOKEN}" \
     --name "${RUNNER_NAME}" \
-    --work ${RUNNER_WORK_DIRECTORY} \
-    --runnergroup ${GROUP} \
+    --work "${RUNNER_WORK_DIRECTORY}" \
+    --runnergroup "${GROUP}" \
     $OPTIONS
 
 echo "Starting GitHub Actions Runner"


### PR DESCRIPTION
Hello👋 . I noticed that Runner Groups and Work Directory do not work well with spaces. This PR intends to fix them, though it would not be a significant scenario...

## Change
- Add quotes to the arguments for `./config.sh` call.

## Testing
- Tested with `Sample Group 1` and `dummy dir` on GitHub Enterprise Server.

### After Change

```
$ docker build -f redhat-ubi8-actions-runner/Dockerfile -t redhat-ubi8-actions-runner \
  --build-arg "GH_RUNNER_VERSION=2.289.2" \
  --no-cache .
```

```
$ docker run -d \
  -e "GITHUB_SERVER=$GITHUB_SERVER" \
  -e "RUNNER_ORGANIZATION_URL=$RUNNER_ORGANIZATION_URL" \
  -e "RUNNER_WORK_DIRECTORY=dummy dir" \
  -e "GITHUB_TOKEN=$GITHUB_TOKEN" \
  redhat-ubi8-actions-runner

0a3594c1d486bf4bc0ae7d0d6b725e4fb5115946c01fdf44690037d1d5274532
```

```
$ docker exec -it 0a3594c1d486 ls "dummy dir"
_PipelineMapping  _actions  _temp  _tool  actions-sample
```

![screenshots](https://user-images.githubusercontent.com/1172471/162616774-c386aaca-337e-4fa0-a099-fcf490c92858.png)

### Before Change

```
$ docker run -d \
  -e "GITHUB_SERVER=$GITHUB_SERVER" \
  -e "RUNNER_ORGANIZATION_URL=$RUNNER_ORGANIZATION_URL" \
  -e "GITHUB_TOKEN=$GITHUB_TOKEN" \
  -e "RUNNER_WORK_DIRECTORY=dummy dir" \
  -e "RUNNER_GROUP=Sample Group 1" \
  redhat-ubi8-actions-runner

e9749f40ed535981fcd1ce2d290539fa0700cf559377c62addd9900a1fdc2439
```

**group name identification failed**

```
$ docker logs e9749f40ed535981fcd1ce2d290539fa0700cf559377c62addd9900a1fdc2439
...
Could not find any self-hosted runner group named "Sample".
```

**name after space was cut off (becomes "dummy" instead of "dummy dir")**
```
$ docker exec -it 574cdead4915 /bin/bash
[actions@574cdead4915 ~]$ ls
_diag  bin  config.sh  dummy  entrypoint.sh  env.sh  externals	run-helper.cmd.template  run-helper.sh.template  run.sh  runsvc.sh  safe_sleep.sh  svc.sh
```